### PR TITLE
Change semantics to avoid duplicate code in expanded output

### DIFF
--- a/tests/retry_impl_method.rs
+++ b/tests/retry_impl_method.rs
@@ -42,8 +42,9 @@ async fn main() {
     let duration = end - start;
 
     // max of 5 retries, waits of 1s, 2s, 4s, 8s, 16s = 31s
+    println!("{:?}", duration);
     assert!(duration > Duration::from_secs(31));
     assert!(duration < Duration::from_millis(31100));
     // initial attempt + 5 retries
-    assert_eq!(6, counter.count);
+    assert_eq!(5, counter.count);
 }

--- a/tests/retry_invalid_configuration.rs
+++ b/tests/retry_invalid_configuration.rs
@@ -1,0 +1,29 @@
+use retry_if::{retry, ExponentialBackoffConfig};
+use std::num::ParseIntError;
+use std::str::FromStr;
+use std::time::Duration;
+
+const INVALID_BACKOFF_CONFIG: ExponentialBackoffConfig = ExponentialBackoffConfig {
+    max_retries: 0,
+    t_wait: Duration::from_secs(1),
+    backoff: 2.0,
+    t_wait_max: None,
+    backoff_max: None,
+};
+
+#[should_panic(expected = "retries failed to produce a value; max_retries must be >= 1")]
+#[tokio::test]
+async fn test_invalid_configuration() {
+    let _ = invalid_retryable().await;
+}
+
+fn retry_if(_: &Result<i32, ParseIntError>) -> bool {
+    false
+}
+
+#[retry(INVALID_BACKOFF_CONFIG, retry_if)]
+async fn invalid_retryable() -> Result<i32, ParseIntError> {
+    // need async call to detect improper usage in macro
+    tokio::time::sleep(Duration::from_secs(0)).await;
+    i32::from_str("3")
+}

--- a/tests/retry_real_return_value.rs
+++ b/tests/retry_real_return_value.rs
@@ -1,0 +1,29 @@
+use retry_if::{retry, ExponentialBackoffConfig};
+use std::num::ParseIntError;
+use std::str::FromStr;
+use std::time::Duration;
+
+const BACKOFF_CONFIG: ExponentialBackoffConfig = ExponentialBackoffConfig {
+    max_retries: 5,
+    t_wait: Duration::from_secs(1),
+    backoff: 2.0,
+    t_wait_max: None,
+    backoff_max: None,
+};
+
+#[tokio::test]
+async fn test_simple_retryable() {
+    let val = retryable().await;
+    assert_eq!(Ok(3), val);
+}
+
+fn retry_if(_: &Result<i32, ParseIntError>) -> bool {
+    false
+}
+
+#[retry(BACKOFF_CONFIG, retry_if)]
+async fn retryable() -> Result<i32, ParseIntError> {
+    // need async call to detect improper usage in macro
+    tokio::time::sleep(Duration::from_secs(0)).await;
+    i32::from_str("3")
+}

--- a/tests/retry_tracing.rs
+++ b/tests/retry_tracing.rs
@@ -47,7 +47,7 @@ async fn main() {
     assert!(duration > Duration::from_secs(31));
     assert!(duration < Duration::from_millis(31100));
     // initial attempt + 5 retries
-    assert_eq!(6, counter.count);
+    assert_eq!(5, counter.count);
 }
 
 fn set_up_logging() {

--- a/tests/retry_trait_impl_method.rs
+++ b/tests/retry_trait_impl_method.rs
@@ -36,6 +36,14 @@ impl Counter for SimpleCounter {
     }
 }
 
+impl SimpleCounter {
+    // another self-using function to show that counter
+    //  isn't consumed or borrowed inappropriately
+    async fn double_count(&mut self) {
+        self.count *= 2;
+    }
+}
+
 #[tokio::test]
 async fn main() {
     let mut counter = SimpleCounter { count: 0 };
@@ -49,6 +57,8 @@ async fn main() {
     // waits of 1s, 2s, 2.5s, 2.5s, at 8s waiting another 2.5s would exceed time, so it exits early
     assert!(duration > Duration::from_secs(8));
     assert!(duration < Duration::from_millis(8100));
-    // initial attempt + 4 retries
     assert_eq!(5, counter.count);
+
+    counter.double_count().await;
+    assert_eq!(10, counter.count);
 }


### PR DESCRIPTION
This uses an `Option<?>` to store the result instead of first computing the value, then double-expanding the wrapped function's block of code inside the loop. 

The only side effect of this approach is the possibility of a panic, and that `max_retries` in the configuration is now more like `max_attempts` or `max_tries`, since the loop encompasses the first attempt. If that change is fine, I'll rename it more appropriately. Functionally it's gone from describing "retry at most X times", to "attempt at most X times". I'm indifferent to either way, but it just needs to be named correctly and documented.

Otherwise this adds a few tests for cases that came up with real use-cases of mine that the test suite wasn't covering, and a test to show the panic for a backoff that has <= 0 for the `max_retries` value.

Without dumping the entire expanded output, the following code expands like this:

```
#[tokio::main]
async fn main() {
    let val = retryable().await;
    assert_eq!(Ok(3), val);
}

fn retry_if(_: &Result<i32, ParseIntError>) -> bool {
    false
}

#[retry(BACKOFF_CONFIG, retry_if)]
async fn retryable() -> Result<i32, ParseIntError> {
    tokio::time::sleep(Duration::from_secs(0)).await;
    i32::from_str("3")
}
```

```
async fn retryable() -> Result<i32, ParseIntError> {
    let start = tokio::time::Instant::now();
    let backoff_max = BACKOFF_CONFIG.backoff_max.unwrap_or(std::time::Duration::MAX);
    let max_tries = BACKOFF_CONFIG.max_retries;
    let mut result = None;
    for attempt in 0..max_tries {
        result = Some({  // < ------------------------------ single code expansion here
            tokio::time::sleep(Duration::from_secs(0)).await;
            i32::from_str("3")
        });
        if !retry_if(result.as_ref().unwrap()) {
            break;
        }
        let retry_wait = BACKOFF_CONFIG
            .t_wait
            .mul_f64(BACKOFF_CONFIG.backoff.powi(attempt))
            .min(backoff_max);
        if let Some(max_wait) = BACKOFF_CONFIG.t_wait_max {
            let now = tokio::time::Instant::now();
            let since_start = now - start;
            let will_exceed_time = since_start + retry_wait > max_wait;
            if will_exceed_time {
                break;
            }
        }

        // REMOVED - much tracing-related expanded output

        tokio::time::sleep(retry_wait).await;
    }
    result.take().expect("retries failed to produce a value; max_retries must be >= 1")
}
```